### PR TITLE
Fix deprecated code

### DIFF
--- a/GAPI.class.php
+++ b/GAPI.class.php
@@ -72,7 +72,7 @@ class GAPI
      * $password  = The API token.
      *
      */
-    function GAPI($username, $password)
+    public function __construct($username, $password)
     {
         $this->username = $username;
         $this->password = $password;

--- a/getanewsletter.php
+++ b/getanewsletter.php
@@ -459,7 +459,9 @@ class GetaNewsletter extends WP_Widget {
     }
 }
 
-add_action('widgets_init', create_function('', 'return register_widget("GetaNewsletter");'));
+add_action('widgets_init', function() {
+    register_widget( 'GetaNewsletter' );
+});
 
 register_activation_hook(__FILE__, array('GetaNewsletter', 'install'));
 function getanewsletter_load_plugin_textdomain() {


### PR DESCRIPTION
The plugin was throwing warnings because of deprecated php code. It should be fixed now.